### PR TITLE
Deletion of moderatable objects

### DIFF
--- a/src/Moderatable.php
+++ b/src/Moderatable.php
@@ -178,4 +178,18 @@ trait Moderatable
         return array_merge(parent::getDates(), [$this->getModeratedAtColumn()]);
     }
 
+
+    /**
+     * Perform the actual delete query on this model instance.
+     * Ovveriding the \Illuminate\Database\Eloquent\Model::performDeleteOnModel method in order to
+     * allow the deletion of Moderatable objects of any status when using the delete() method on a loaded object
+     *
+     * @return void
+     */
+    protected function performDeleteOnModel()
+    {
+        $this->setKeysForSaveQuery($this->newQueryWithoutScopes())->delete();
+    }
+
+
 }

--- a/src/ModerationScope.php
+++ b/src/ModerationScope.php
@@ -97,7 +97,7 @@ class ModerationScope implements ScopeInterface
         }
 
         $builder->onDelete(function (Builder $builder) {
-            $column = $this->getApprovedAtColumn($builder);
+            $column = $builder->getModel()->getModeratedAtColumn();
 
             return $builder->update([
                 $column => $builder->getModel()->freshTimestampString(),


### PR DESCRIPTION
Hi,

I think that there is a little when trying to delete a moderatable object by ising the delete() method. Indeed the eloquent delete method applies again the query scopes, so it is impossible to perform the delete on "rejected" adn "pending" objects.
I simply redefined the performDeleteOnModel in teh emoderatable class. Possibly there is a more elegant solution.