### PR TITLE
update travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: php
 
 php:
   - 5.6
-  - hhvm
+  - 7.0
 
 sudo: false
 
@@ -13,7 +13,7 @@ cache:
     - $HOME/.composer/cache
 
 before_install:
-  - if [[ $TRAVIS_PHP_VERSION != hhvm ]]; then phpenv config-rm xdebug.ini; fi;
+  - phpenv config-rm xdebug.ini; fi;
 
 install:
   - composer install --dev --prefer-source --no-interaction


### PR DESCRIPTION
Since `php 7.0` is out and Laravel 5.3 does not support `hhvm` anymore this change would make sense.