### PR TITLE
Remove references to AppUser to allow using custom models structure

### DIFF
--- a/src/ModerationScope.php
+++ b/src/ModerationScope.php
@@ -2,7 +2,6 @@
 
 namespace Hootlex\Moderation;
 
-use App\User;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -26,6 +26,7 @@ abstract class BaseTestCase extends TestCase
 
     function actingAsUser()
     {
-        return $this->actingAs(\App\User::create(['name' => 'tester', 'email' => mt_rand(1,9999).'tester@test.com', 'password' => 'password']));
+        $userModel = config('auth.providers.users.model', config('auth.model', 'App\User'));
+        return $this->actingAs($userModel::create(['name' => 'tester', 'email' => mt_rand(1,9999).'tester@test.com', 'password' => 'password']));
     }
 }


### PR DESCRIPTION
Hey there :)

We're using a custom-but-quite-common models structure, using App\Models instead of App as base namespace.
Thus, ModerationScope using App\User is raising errors in our case, and so is the BaseTestCase acting as App\User.

Therefore, I only removed the use statement in ModerationScope (wasn't used), and used adamwathan/eloquent-oauth method of retrieving the user class from ` config('auth.providers.users.model', config('auth.model', 'App\User'))` for BaseTestCase.

Hope it's okay, and thanks for this great package.
Cheers,