### PR TITLE
Support Auto-Discovery / Fix missing lib for testing / Upgrade phpunit / Make it compatible with PHP 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: php
 
 php:
-  - 5.6
-  - 7.0
+  - 7.1
   - 7.2
 
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - 5.6
   - 7.0
+  - 7.2
 
 sudo: false
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,7 @@ First, install the package through Composer.
 composer require hootlex/laravel-moderation
 ```
 
-Then include the service provider inside `config/app.php`.
-
+If you are using Laravel < 5.5, you need to add Hootlex\Moderation\ModerationServiceProvider to your `config/app.php` providers array:
 ```php
 'providers' => [
     ...

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ]
   },
   "require": {
-    "php": "^7.1.3"
+    "php": ">=5.4.0"
   },
   "require-dev": {
     "phpunit/phpunit": "7.0",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ]
   },
   "require": {
-    "php": ">=5.4.0"
+    "php": "^7.1.3"
   },
   "require-dev": {
     "phpunit/phpunit": "7.0",

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,9 @@
     "php": ">=5.4.0"
   },
   "require-dev": {
-    "phpunit/phpunit" : "5.*",
-    "laravel/laravel": "5.*"
+    "phpunit/phpunit" : "7.0",
+    "laravel/laravel": "5.*",
+    "nunomaduro/collision": "^2.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,12 @@
 {
   "name": "hootlex/laravel-moderation",
   "description": "A simple Content Moderation System for Laravel 5.* that allows you to Approve or Reject resources like posts, comments, users, etc.",
-  "keywords": ["laravel", "moderation", "moderation-system", "content-moderation"],
+  "keywords": [
+    "laravel",
+    "moderation",
+    "moderation-system",
+    "content-moderation"
+  ],
   "license": "MIT",
   "authors": [
     {
@@ -19,13 +24,20 @@
     "php": ">=5.4.0"
   },
   "require-dev": {
-    "phpunit/phpunit" : "7.0",
+    "phpunit/phpunit": "7.0",
     "laravel/laravel": "5.*",
     "nunomaduro/collision": "^2.0"
   },
   "autoload": {
     "psr-4": {
       "Hootlex\\Moderation\\": "src/"
+    }
+  },
+  "extra": {
+    "laravel": {
+      "providers": [
+        "Hootlex\\Moderation\\ModerationServiceProvider"
+      ]
     }
   }
 }

--- a/src/ModerationScope.php
+++ b/src/ModerationScope.php
@@ -317,7 +317,7 @@ class ModerationScope implements Scope
      */
     protected function getStatusColumn(Builder $builder)
     {
-        if (count($builder->getQuery()->joins) > 0) {
+        if ($builder->getQuery()->joins && count($builder->getQuery()->joins) > 0) {
             return $builder->getModel()->getQualifiedStatusColumn();
         } else {
             return $builder->getModel()->getStatusColumn();

--- a/tests/ModerationScopeTest.php
+++ b/tests/ModerationScopeTest.php
@@ -69,12 +69,6 @@ class ModerationScopeTest extends BaseTestCase
     }
 
     /** @test */
-    public function it_returns_only_postponed_stories()
-    {
-
-    }
-
-    /** @test */
     public function it_returns_stories_including_pending_ones()
     {
         $this->createPost([$this->status_column => Status::PENDING], 5);


### PR DESCRIPTION
 * Support Auto-Discovery
 * Fix missing lib for testing
 * Upgrade phpunit
 * Make it compatible with PHP 7.2 (related to #29)
 * Remove php 5.6 7.0 compatibility

We have to remove PHP 5.6, 7.0 compatibility because laravel 5.6 and phpunit 7 require php ^7.1.3 .
Maybe create a branch before merging this PR to keep a old support branch for old version. 
@hootlex What do you think about it ?