### PR TITLE
Fix failing tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
   "require-dev": {
     "phpunit/phpunit": "7.0",
     "laravel/laravel": "5.*",
-    "nunomaduro/collision": "^2.0"
+    "nunomaduro/collision": "^2.0",
+    "beyondcode/laravel-dump-server": "~1.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Added the beyondcode/laravel-dump-server dependency to fix failing tests for Laravel 5.7