### PR TITLE
Fixes array cast incompatibility

### DIFF
--- a/src/Moderatable.php
+++ b/src/Moderatable.php
@@ -62,7 +62,7 @@ trait Moderatable
     public function markApproved()
     {
         $new = (new static)->newQueryWithoutScope(new ModerationScope())->approve($this->id);
-        return $this->setRawAttributes($new->attributesToArray());
+        return $this->setRawAttributes($new->attributes);
     }
 
     /**
@@ -73,7 +73,7 @@ trait Moderatable
     public function markRejected()
     {
         $new = (new static)->newQueryWithoutScope(new ModerationScope())->reject($this->id);
-        return $this->setRawAttributes($new->attributesToArray());
+        return $this->setRawAttributes($new->attributes);
     }
 
     /**
@@ -84,7 +84,7 @@ trait Moderatable
     public function markPostponed()
     {
         $new = (new static)->newQueryWithoutScope(new ModerationScope())->postpone($this->id);
-        return $this->setRawAttributes($new->attributesToArray());
+        return $this->setRawAttributes($new->attributes);
     }
 
     /**
@@ -95,7 +95,7 @@ trait Moderatable
     public function markPending()
     {
         $new = (new static)->newQueryWithoutScope(new ModerationScope())->pend($this->id);
-        return $this->setRawAttributes($new->attributesToArray());
+        return $this->setRawAttributes($new->attributes);
     }
 
     /**


### PR DESCRIPTION
For models with an array cast, the attributesToArray() method returns the cast array instead of the serialized array. So usage of `markApproved(), markRejected(), markPostponed() and markPending()` methods of the `Moderatable` trait throw a DB exception due to the attempt to save the raw array instead of the serialized array. So this fix changes the `$new->attributesToArray()` used in the mentioned methods to `$new->attributes`.